### PR TITLE
Add case "heptapod" item into func RemoteIdLink()

### DIFF
--- a/pkg/app/handler/packages/utils.go
+++ b/pkg/app/handler/packages/utils.go
@@ -391,6 +391,8 @@ func RemoteIdLink(remoteId models.RemoteId) string {
 		return "http://freshmeat.sourceforge.net/projects/" + remoteId.Id
 	case "gitlab":
 		return "https://gitlab.com/" + remoteId.Id
+	case "heptapod":
+		return "https://foss.heptapod.net/" + remoteId.Id
 	default:
 		return ""
 	}


### PR DESCRIPTION
After discussion on gentoo-dev [mailing list](https://archives.gentoo.org/gentoo-dev/message/d12a0ebb34a4c87fc9964b6631b19611) new remote-id item "heptapod"
was added to 'dtd/metadata.dtd'([link to commit](https://gitweb.gentoo.org/data/dtd.git/commit/?id=b4185459f715d9b9ca4ee98b9254ae222bf4059e)) 
and to 'xml-schema/metadata.xsd'([link to commit](https://gitweb.gentoo.org/data/xml-schema.git/commit/?id=cd3e62ffb7761008bba5eed179805adc10f1e627)).

This patch adds the remote-id item "heptapod" to RemoteIdLink()
to provide Remote-ID URLs to packages project pages
that are hosted on https://foss.heptapod.net/

The item is added to the end of list due to small number of such projects.
