### PR TITLE
Link to repology by Gentoo package coordinates

### DIFF
--- a/web/templates/packages/resources.tmpl
+++ b/web/templates/packages/resources.tmpl
@@ -21,7 +21,7 @@
             </dd>
             <dd>
                 <span class="fa fa-fw fa-sort-numeric-desc"></span>
-                <a href="https://repology.org/project/{{.Package.Name}}" target="_blank">
+                <a href="https://repology.org/tools/project-by?repo=gentoo&name_type=srcname&target_page=project_versions&name={{.Package.Categoy}}/{{Package.Name}}" target="_blank">
                     Repology
                 </a>
             </dd>


### PR DESCRIPTION
Some 'Repology' links on p.g.o point to "unkown projects". For example
on https://packages.gentoo.org/packages/games-simulation/EmptyEpsilon
the 'Repology' link points to
https://repology.org/project/EmptyEpsilon, however the Repology name
is emptyepsilon.

The Repology developer thankfully pointed me to
https://repology.org/tools/project-by?repo=gentoo&name_type=srcname&target_page=project_versions,
which allows us to link from p.g.o using the Gentoo package
coordinates. This has two advantages
1) It is robust and functional in the case described above
2) It supports packages with the same name (but different categories)

Hence, this changes the 'Repology' link to use Gentoo package
coordinates.

Closes: https://bugs.gentoo.org/845009
Signed-off-by: Florian Schmaus <flow@gentoo.org>