### PR TITLE
Update list of remote-ids

### DIFF
--- a/pkg/app/handler/packages/utils.go
+++ b/pkg/app/handler/packages/utils.go
@@ -381,8 +381,6 @@ func RemoteIdLink(remoteId models.RemoteId) string {
 		return "https://github.com/" + remoteId.Id
 	case "gitlab":
 		return "https://gitlab.com/" + remoteId.Id
-	case "gitorious":
-		return "https://gitorious.org/" + remoteId.Id + "/"
 	case "google-code":
 		return "https://code.google.com/archive/p/" + remoteId.Id + "/"
 	case "heptapod":
@@ -402,7 +400,7 @@ func RemoteIdLink(remoteId models.RemoteId) string {
 	case "sourceforge":
 		return "https://sourceforge.net/projects/" + remoteId.Id + "/"
 	case "vim":
-		return "https://vim.org/scripts/script.php?script_id=" + remoteId.Id
+		return "https://www.vim.org/scripts/script.php?script_id=" + remoteId.Id
 	default:
 		return ""
 	}


### PR DESCRIPTION
Drop gitorious, update vim. See wiki page:
https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Upstream_remote-id_types

Signed-off-by: Ulrich Müller <ulm@gentoo.org>