### PR TITLE
templates: fix swapped 'testing' and 'stable'

### DIFF
--- a/web/templates/arches/changedVersionRows.tmpl
+++ b/web/templates/arches/changedVersionRows.tmpl
@@ -60,9 +60,9 @@
                         <p>
                             {{ range $.UserPreferences.Arches.Visible }}
                                 {{if contains (print " " $version.Keywords " ") (print " " . " ")}}
-                                    <span class="label kk-keyword-stable" title="{{$version.Version}} is testing on {{.}}">{{.}}</span>
+                                    <span class="label kk-keyword-stable" title="{{$version.Version}} is stable on {{.}}">{{.}}</span>
                                 {{else if contains (print " " $version.Keywords " ") (print "~" . " ")}}
-                                    <span class="label kk-keyword-testing" title="{{$version}} is stable on {{.}}">~{{.}}</span>
+                                    <span class="label kk-keyword-testing" title="{{$version}} is testing on {{.}}">~{{.}}</span>
                                 {{else}}
                                     <span class="label kk-keyword-unknown" title="{{$version.Version}} is unknown on {{.}}">?{{.}}</span>
                                 {{end}}

--- a/web/templates/packages/changedVersionRow.tmpl
+++ b/web/templates/packages/changedVersionRow.tmpl
@@ -60,9 +60,9 @@
                         {{ $arches := mkSlice "amd64" "x86" "alpha" "arm" "arm64" "hppa" "ia64" "ppc" "ppc64" "riscv" "sparc" }}
                         {{ range $arches }}
                             {{if contains (print " " $.Keywords " ") (print " " . " ")}}
-                                <span class="label kk-keyword-stable" title="{{$.Version}} is testing on {{.}}">{{.}}</span>
+                                <span class="label kk-keyword-stable" title="{{$.Version}} is stable on {{.}}">{{.}}</span>
                             {{else if contains (print " " $.Keywords " ") (print "~" . " ")}}
-                                <span class="label kk-keyword-testing" title="{{$.Version}} is stable on {{.}}">~{{.}}</span>
+                                <span class="label kk-keyword-testing" title="{{$.Version}} is testing on {{.}}">~{{.}}</span>
                             {{else}}
                                 <span class="label kk-keyword-unknown" title="{{$.Version}} is unknown on {{.}}">?{{.}}</span>
                             {{end}}


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/867925

Signed-off-by: Matt Jolly <Matt.Jolly@footclan.ninja>