### PR TITLE
Improve links for creation of new bugs

### DIFF
--- a/web/templates/packages/components/bugs.tmpl
+++ b/web/templates/packages/components/bugs.tmpl
@@ -75,7 +75,7 @@
                     </div>
                     <div class="col-md-8 pt-3">
                         <h2>Good job! There are no bugs.</h2>
-                        <span>You think something is missing here? <br/> Start with filling a <a href="https://bugs.gentoo.org/enter_bug.cgi">new bug</a>.</span>
+                        <span>You think something is missing here? <br/> Start with filling a <a href="https://bugs.gentoo.org/enter_bug.cgi?product=Gentoo%20Linux&component=Current%20packages&short_desc={{.Package.Category}}%2F{{.Package.Name}}:%20%3CADD%20SUMMARY%20HERE%3E">new bug</a>.</span>
                     </div>
                 </div>
             {{- end }}
@@ -90,7 +90,7 @@
                 <span class="text-muted">
                     Gentoo Bugzilla is where we track bugs of Gentoo and its packages; you are welcome to report, confirm and resolve bugs:
                     <ul>
-                        <li><a href="https://bugs.gentoo.org/enter_bug.cgi">File a new Bug</a></li>
+                        <li><a href="https://bugs.gentoo.org/enter_bug.cgi?product=Gentoo%20Linux&component=Current%20packages&short_desc={{.Package.Category}}%2F{{.Package.Name}}:%20%3CADD%20SUMMARY%20HERE%3E">File a new Bug</a></li>
                         <li><a href="https://bugs.gentoo.org/">Confirm a bug</a></li>
                         <li><a href="https://wiki.gentoo.org/wiki/Bugday">Participate in our monthly Bugday</a></li>
                     </ul>

--- a/web/templates/packages/components/security.tmpl
+++ b/web/templates/packages/components/security.tmpl
@@ -27,7 +27,7 @@
                     </div>
                     <div class="col-md-8 pt-3">
                         <h2>There are no open security bugs.</h2>
-                        <span>You think something is missing here? <br/> Start with filling a <a href="https://bugs.gentoo.org/">new security bug</a>.</span>
+                        <span>You think something is missing here? <br/> Start with filling a <a href="https://bugs.gentoo.org/enter_bug.cgi?product=Gentoo%20Security&component=Vulnerabilities&short_desc={{.Package.Category}}%2F{{.Package.Name}}:%20%3CADD%20SUMMARY%20HERE%3E">new security bug</a>.</span>
                     </div>
                 </div>
             {{- end -}}
@@ -40,7 +40,10 @@
             </h4>
             <div class="collapse show" id="collapseDescription">
                 <span class="text-muted">
-                    Please file new vulnerability reports on <a href="https://bugs.gentoo.org/">Gentoo Bugzilla</a> and assign them to the Gentoo Security product and Vulnerabilities component.
+                    Please file new vulnerability reports on Gentoo Bugzilla and assign them to the Gentoo Security product and Vulnerabilities component:
+                    <ul>
+                        <li><a href="https://bugs.gentoo.org/enter_bug.cgi?product=Gentoo%20Security&component=Vulnerabilities&short_desc={{.Package.Category}}%2F{{.Package.Name}}:%20%3CADD%20SUMMARY%20HERE%3E">File a new security bug</a></li>
+                    </ul>
                 </span>
             </div>
             <h4 class="mt-4">


### PR DESCRIPTION
This saves some time for reporters and prevents accidental typos in package names

Example link for generic component bug:
https://bugs.gentoo.org/enter_bug.cgi?product=Gentoo%20Linux&component=Current%20packages&short_desc=dev-lang%2Fperl:%20%3CADD%20SUMMARY%20HERE%3E

Example link for new vulnerability bug:
https://bugs.gentoo.org/enter_bug.cgi?product=Gentoo%20Security&component=Vulnerabilities&short_desc=dev-lang%2Fperl:%20%3CADD%20SUMMARY%20HERE%3E