### PR TITLE
changelog: rename "RSS Feed" to "Atom feed"

### DIFF
--- a/pkg/app/handler/packages/components/changelog.templ
+++ b/pkg/app/handler/packages/components/changelog.templ
@@ -36,7 +36,7 @@ templ Changelog(atom string, commits []*models.Commit) {
 							}
 							target="_blank"
 						>
-							<span class="fa fa-fw fa-rss text-dark"></span> RSS Feed
+							<span class="fa fa-fw fa-rss text-dark"></span> Atom feed
 						</a>
 					</span>
 				</span>


### PR DESCRIPTION
It is actually an Atom feed and not an RSS feed. And we use "Atom feed" already in other places, so this makes things consistent again.