### PR TITLE
Update list of remote-ids

### DIFF
--- a/pkg/app/handler/packages/utils.go
+++ b/pkg/app/handler/packages/utils.go
@@ -257,7 +257,7 @@ func remoteIdLink(remoteId models.RemoteId) string {
 	case "sourcehut":
 		return "https://sr.ht/" + remoteId.Id + "/"
 	case "vim":
-		return "https://vim.org/scripts/script.php?script_id=" + remoteId.Id
+		return "https://www.vim.org/scripts/script.php?script_id=" + remoteId.Id
 	default:
 		return ""
 	}


### PR DESCRIPTION
I found this commit from 2022 in my local fork. Apparently I forgot to file a PR at the time.

It had contained more updates, but all of them have been resolved in the meantime, except the remaining one for `vim`.

@gentoo/vim
